### PR TITLE
Enable Caddy HTTP cache

### DIFF
--- a/frankenphp-8.2.yaml
+++ b/frankenphp-8.2.yaml
@@ -71,7 +71,8 @@ pipeline:
         --with github.com/caddyserver/caddy/v2=/usr/src/caddy \
         --with github.com/dunglas/caddy-cbrotli \
         --with github.com/dunglas/mercure/caddy \
-        --with github.com/dunglas/vulcain/caddy
+        --with github.com/dunglas/vulcain/caddy \
+        --with github.com/caddyserver/cache-handler
 
   - uses: strip
 

--- a/frankenphp-8.2.yaml
+++ b/frankenphp-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: frankenphp-8.2
   version: 1.2.5
-  epoch: 2
+  epoch: 3
   description: "FrankenPHP"
   copyright:
     - license: MIT

--- a/frankenphp-8.3.yaml
+++ b/frankenphp-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: frankenphp-8.3
   version: 1.2.5
-  epoch: 2
+  epoch: 3
   description: "FrankenPHP"
   copyright:
     - license: MIT

--- a/frankenphp-8.3.yaml
+++ b/frankenphp-8.3.yaml
@@ -71,7 +71,8 @@ pipeline:
         --with github.com/caddyserver/caddy/v2=/usr/src/caddy \
         --with github.com/dunglas/caddy-cbrotli \
         --with github.com/dunglas/mercure/caddy \
-        --with github.com/dunglas/vulcain/caddy
+        --with github.com/dunglas/vulcain/caddy \
+        --with github.com/caddyserver/cache-handler
 
   - uses: strip
 

--- a/images/frankenphp/Caddyfile
+++ b/images/frankenphp/Caddyfile
@@ -1,4 +1,4 @@
-{  
+{
 	{$CADDY_GLOBAL_OPTIONS}
 
 	frankenphp {

--- a/images/frankenphp/Caddyfile
+++ b/images/frankenphp/Caddyfile
@@ -1,4 +1,6 @@
 {
+    cache
+    
 	{$CADDY_GLOBAL_OPTIONS}
 
 	frankenphp {
@@ -16,6 +18,8 @@
 {$CADDY_EXTRA_CONFIG}
 
 {$SERVER_NAME:localhost} {
+    cache
+
 	#log {
 	#	# Redact the authorization query parameter that can be set by Mercure
 	#	format filter {

--- a/images/frankenphp/Caddyfile
+++ b/images/frankenphp/Caddyfile
@@ -1,6 +1,4 @@
-{
-    cache
-    
+{  
 	{$CADDY_GLOBAL_OPTIONS}
 
 	frankenphp {
@@ -18,8 +16,6 @@
 {$CADDY_EXTRA_CONFIG}
 
 {$SERVER_NAME:localhost} {
-    cache
-
 	#log {
 	#	# Redact the authorization query parameter that can be set by Mercure
 	#	format filter {


### PR DESCRIPTION
One of the advantages of using Caddy/FrankenPHP is its HTTP cache support.

See https://api-platform.com/docs/core/performance/#built-in-caddy-http-cache