### PR TITLE
frankenphp: remove expose 8000

### DIFF
--- a/images/frankenphp/Dockerfile
+++ b/images/frankenphp/Dockerfile
@@ -28,7 +28,6 @@ LABEL org.opencontainers.image.licenses=MIT
 LABEL org.opencontainers.image.vendor="Shyim"
 
 WORKDIR /app
-EXPOSE 8000
     
 ENTRYPOINT [ "/usr/bin/frankenphp", "run" ]
 CMD [ "--config", "/etc/caddy/Caddyfile" ]


### PR DESCRIPTION
By default it listens on port 80, we don't need that copy paste error