### PR TITLE
docs: fix example ports for caddy

### DIFF
--- a/images/caddy/README.md
+++ b/images/caddy/README.md
@@ -16,10 +16,10 @@ COPY . /var/www/html
 
 ```shell
 docker build -t my-image .
-docker run -p 8080:8080 my-image
+docker run -p 8000:8000 my-image
 ```
 
-You can run it for testing purposes also directly, `docker run --rm -p 8080:8080 ghcr.io/shyim/wolfi-php/caddy:8.3` and you should see at `http://localhost:8000` the php info page.
+You can run it for testing purposes also directly, `docker run --rm -p 8000:8000 ghcr.io/shyim/wolfi-php/caddy:8.3` and you should see at `http://localhost:8000` the php info page.
 
 ## PHP Extensions / PHP Configuration
 


### PR DESCRIPTION
did fall over this when copying the examples :D the image exposed :8000 but docs reference :8080 ;) 