### PR TITLE
docker: add HIVEMIND_SKIP_ENV variable to caddy and nginx Dockerfiles

### DIFF
--- a/images/caddy/Dockerfile
+++ b/images/caddy/Dockerfile
@@ -4,7 +4,8 @@ FROM ghcr.io/shyim/wolfi-php/fpm:${PHP_VERSION}
 ENV PHP_FPM_LISTEN=/tmp/php-fpm.sock \
     PHP_FPM_ACCESS_LOG=/dev/null \
     SERVER_NAME=:8000 \
-    CADDY_SERVER_EXTRA_DIRECTIVES=log
+    CADDY_SERVER_EXTRA_DIRECTIVES=log \
+    HIVEMIND_SKIP_ENV=1
 
 RUN <<EOF
 set -eo pipefail

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -2,7 +2,8 @@ ARG PHP_VERSION=8.3
 FROM ghcr.io/shyim/wolfi-php/fpm:${PHP_VERSION}
 
 ENV PHP_FPM_LISTEN=/tmp/php-fpm.sock \
-    PHP_FPM_ACCESS_LOG=/dev/null
+    PHP_FPM_ACCESS_LOG=/dev/null \
+    HIVEMIND_SKIP_ENV=1
 
 RUN <<EOF
 set -eo pipefail


### PR DESCRIPTION
hivemind loads unexpectedly the .env file and starts php-fpm with them, so it's not possible to change the values in .env

"Hard env" should be set directly to the container to be transparent