### PR TITLE
Add merged-usrsbin dependency and update php-fpm paths

### DIFF
--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2
   version: 8.2.28
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -12,6 +12,7 @@ package:
       - ${{package.name}}-config
       - libxml2
       - merged-bin
+      - merged-usrsbin
       - wolfi-baselayout
 
 environment:
@@ -74,6 +75,7 @@ pipeline:
       EXTENSION_DIR=/usr/lib/php/modules ./configure \
         --prefix=/usr \
         --libdir=/usr/lib/php \
+        --sbindir=/usr/bin \
         --datadir=/usr/share/php \
         --sysconfdir=/etc/php \
         --localstatedir=/var \
@@ -218,6 +220,7 @@ subpackages:
       runtime:
         - "${{package.name}}-${{range.key}}-config"
         - merged-bin
+        - merged-usrsbin
         - wolfi-baselayout
       provides:
         - php-${{range.key}}=${{package.full-version}}
@@ -236,6 +239,7 @@ subpackages:
         - php-${{range.key}}-config=${{package.full-version}}
       runtime:
         - merged-bin
+        - merged-usrsbin
         - wolfi-baselayout
     pipeline:
       - runs: |
@@ -252,6 +256,7 @@ subpackages:
         - php-dev=${{package.full-version}}
       runtime:
         - merged-bin
+        - merged-usrsbin
         - wolfi-baselayout
     pipeline:
       - uses: split/dev
@@ -275,6 +280,7 @@ subpackages:
         - php-cgi=${{package.full-version}}
       runtime:
         - merged-bin
+        - merged-usrsbin
         - wolfi-baselayout
     pipeline:
       - runs: |
@@ -288,6 +294,7 @@ subpackages:
         - php-dbg=${{package.full-version}}
       runtime:
         - merged-bin
+        - merged-usrsbin
         - wolfi-baselayout
     pipeline:
       - runs: |
@@ -300,19 +307,24 @@ subpackages:
       runtime:
         - "${{package.name}}-fpm-config"
         - merged-bin
+        - merged-usrsbin
         - wolfi-baselayout
       provides:
         - php-fpm=${{package.full-version}}
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/sbin
-          mv ${{targets.destdir}}/usr/sbin/php-fpm ${{targets.subpkgdir}}/usr/sbin/
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/php-fpm ${{targets.subpkgdir}}/usr/bin/
 
   - name: ${{package.name}}-fpm-config
     description: PHP 8.2 FastCGI Process Manager (FPM) configuration
     dependencies:
       provides:
         - php-fpm-config=${{package.full-version}}
+      runtime:
+        - merged-bin
+        - merged-usrsbin
+        - wolfi-baselayout
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc/php/php-fpm.d

--- a/php-frankenphp-8.2.yaml
+++ b/php-frankenphp-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-frankenphp-8.2
   version: 8.2.28
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -12,6 +12,7 @@ package:
       - ${{package.name}}-config
       - libxml2
       - merged-bin
+      - merged-usrsbin
       - wolfi-baselayout
 
 environment:
@@ -73,6 +74,7 @@ pipeline:
         --enable-zend-max-execution-timers \
         --prefix=/usr \
         --libdir=/usr/lib/php \
+        --sbindir=/usr/bin \
         --datadir=/usr/share/php \
         --sysconfdir=/etc/php \
         --localstatedir=/var \
@@ -204,6 +206,7 @@ subpackages:
         - php-config=${{package.full-version}}
       runtime:
         - merged-bin
+        - merged-usrsbin
         - wolfi-baselayout
     pipeline:
       - runs: |
@@ -217,6 +220,7 @@ subpackages:
       runtime:
         - "${{package.name}}-${{range.key}}-config"
         - merged-bin
+        - merged-usrsbin
         - wolfi-baselayout
       provides:
         - php-${{range.key}}=${{package.full-version}}
@@ -235,6 +239,7 @@ subpackages:
         - php-${{range.key}}-config=${{package.full-version}}
       runtime:
         - merged-bin
+        - merged-usrsbin
         - wolfi-baselayout
     pipeline:
       - runs: |
@@ -251,6 +256,7 @@ subpackages:
         - php-dev=${{package.full-version}}
       runtime:
         - merged-bin
+        - merged-usrsbin
         - wolfi-baselayout
     pipeline:
       - uses: split/dev
@@ -267,6 +273,7 @@ subpackages:
         - php-doc=${{package.full-version}}
       runtime:
         - merged-bin
+        - merged-usrsbin
         - wolfi-baselayout
     pipeline:
       - uses: split/manpages
@@ -278,6 +285,7 @@ subpackages:
         - php-cgi=${{package.full-version}}
       runtime:
         - merged-bin
+        - merged-usrsbin
         - wolfi-baselayout
     pipeline:
       - runs: |
@@ -291,6 +299,7 @@ subpackages:
         - php-dbg=${{package.full-version}}
       runtime:
         - merged-bin
+        - merged-usrsbin
         - wolfi-baselayout
     pipeline:
       - runs: |
@@ -303,13 +312,14 @@ subpackages:
       runtime:
         - "${{package.name}}-fpm-config"
         - merged-bin
+        - merged-usrsbin
         - wolfi-baselayout
       provides:
         - php-fpm=${{package.full-version}}
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/sbin
-          mv ${{targets.destdir}}/usr/sbin/php-fpm ${{targets.subpkgdir}}/usr/sbin/
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/php-fpm ${{targets.subpkgdir}}/usr/bin/
 
   - name: ${{package.name}}-fpm-config
     description: PHP 8.2 FastCGI Process Manager (FPM) configuration
@@ -318,6 +328,7 @@ subpackages:
         - php-fpm-config=${{package.full-version}}
       runtime:
         - merged-bin
+        - merged-usrsbin
         - wolfi-baselayout
     pipeline:
       - runs: |


### PR DESCRIPTION
This PR makes the following changes:

1. Adds `merged-usrsbin` dependency alongside `merged-bin` in all runtime dependencies
2. Adds `--sbindir=/usr/bin` to configure options
3. Updates php-fpm installation path from `/usr/sbin` to `/usr/bin`
4. Increases epoch to 1 for both PHP 8.2 packages

These changes align with the recent updates in PHP FrankenPHP 8.3 and ensure consistent binary locations across PHP packages.