### PR TITLE
fix: rebuild php-frankenphp-*-imagick

### DIFF
--- a/php-frankenphp-8.2-imagick.yaml
+++ b/php-frankenphp-8.2-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-frankenphp-8.2-imagick
   version: 3.8.0
-  epoch: 0
+  epoch: 1
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01

--- a/php-frankenphp-8.3-imagick.yaml
+++ b/php-frankenphp-8.3-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-frankenphp-8.3-imagick
   version: 3.8.0
-  epoch: 0
+  epoch: 1
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01

--- a/php-frankenphp-8.4-imagick.yaml
+++ b/php-frankenphp-8.4-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-frankenphp-8.4-imagick
   version: 3.8.0
-  epoch: 0
+  epoch: 1
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01


### PR DESCRIPTION
Hi

a rebuild of the hp-frankenphp-*-imagick  packages with  latest version of ImageMagick in WolfiOS is required to fix the PHP Warning

`PHP Warning:  Version warning: Imagick was compiled against ImageMagick version 1809 but version 1810 is loaded. Imagick will run but may behave surprisingly ...`