### PR TITLE
feat: php-frankenphp-*-msgpack add APCu serializer support

### DIFF
--- a/php-frankenphp-8.2-msgpack.yaml
+++ b/php-frankenphp-8.2-msgpack.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-frankenphp-8.2-msgpack
   version: 3.0.0
-  epoch: 0
+  epoch: 1
   description: "A PHP extension for msgpack"
   copyright:
     - license: BSD-3-Clause
@@ -17,6 +17,7 @@ environment:
       - build-base
       - busybox
       - php-frankenphp-8.2
+      - php-frankenphp-8.2-apcu
       - php-frankenphp-8.2-dev
 
 pipeline:

--- a/php-frankenphp-8.3-msgpack.yaml
+++ b/php-frankenphp-8.3-msgpack.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-frankenphp-8.3-msgpack
   version: 3.0.0
-  epoch: 0
+  epoch: 1
   description: "A PHP extension for msgpack"
   copyright:
     - license: BSD-3-Clause
@@ -17,6 +17,7 @@ environment:
       - build-base
       - busybox
       - php-frankenphp-8.3
+      - php-frankenphp-8.3-apcu
       - php-frankenphp-8.3-dev
 
 pipeline:

--- a/php-frankenphp-8.4-msgpack.yaml
+++ b/php-frankenphp-8.4-msgpack.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-frankenphp-8.4-msgpack
   version: 3.0.0
-  epoch: 0
+  epoch: 1
   description: "A PHP extension for msgpack"
   copyright:
     - license: BSD-3-Clause
@@ -17,6 +17,7 @@ environment:
       - build-base
       - busybox
       - php-frankenphp-8.4
+      - php-frankenphp-8.4-apcu
       - php-frankenphp-8.4-dev
 
 pipeline:


### PR DESCRIPTION
Hi,
adding the build dependency  php-frankenphp-*-apcu  to enabke the APCu serilizer support for msgpack-php 
The APCu support was introduced with  msgpack-php version [3.0.0](https://github.com/msgpack/msgpack-php/releases/tag/msgpack-3.0.0)

